### PR TITLE
goatlap: pin registry/channels to inputs.nixpkgs

### DIFF
--- a/hosts/goatlap/configuration.nix
+++ b/hosts/goatlap/configuration.nix
@@ -15,6 +15,7 @@
 
   imports =
     [ # Include the results of the hardware scan.
+      ../../mixins/common.nix
       ./hardware-configuration.nix
     ];
   

--- a/mixins/common.nix
+++ b/mixins/common.nix
@@ -1,0 +1,12 @@
+{ config, pkgs, lib, inputs, ...}:
+{
+  nix = {
+    extraOptions =
+      let empty_registry = builtins.toFile "empty-flake-registry.json" ''{"flakes":[],"version":2}''; in
+      ''
+        experimental-features = nix-command flakes
+        flake-registry = ${empty_registry}
+      '';
+    registry.nixpkgs.flake = inputs.nixpkgs;
+  };
+}


### PR DESCRIPTION
This ensures that the channel and registry for nixpkgs is only ever pinned to `inputs.nixpkgs` in the `flake.nix`. This means you can run `nix-shell` or `nix shell`, and the nixpkgs you're operating on will only ever come from `inputs.nixpkgs` which is defined in the `flake.nix`